### PR TITLE
Fixed a bug in the background image-set function

### DIFF
--- a/lib/shorthanders/background.js
+++ b/lib/shorthanders/background.js
@@ -1,79 +1,88 @@
-module.exports = function(shorthand, declarations) {
-  var bgProps = {};
+module.exports = function (shorthand, declarations) {
+	var bgProps = {};
 
-  shorthand.properties.forEach(function(property) {
-    bgProps[property] = (declarations[property] ? declarations[property].value.split(',') : []);
+	shorthand.properties.forEach(function (property) {
+		bgProps[property] = (declarations[property] ? declarations[property].value.split(',') : []);
 
-    // Unify bg layers that have commas because of things like line-gradient
-    var unifiedLayers = [];
-    var inParenthese = false;
-    bgProps[property].forEach(function(bgLayer) {
-      if (inParenthese) {
-        unifiedLayers[unifiedLayers.length - 1] = unifiedLayers[unifiedLayers.length - 1] += ',' + bgLayer;
+		// Unify bg layers that have commas because of things like line-gradient
+		var unifiedLayers = [];
+		var inParenthese = false;
 
-        if (bgLayer.indexOf(')') > -1) {
-          inParenthese = false;
-        }
-      }
-      else {
-        unifiedLayers.push(bgLayer);
+		bgProps[property].forEach(function (bgLayer) {
+			if (inParenthese) {
+				unifiedLayers[unifiedLayers.length - 1] = unifiedLayers[unifiedLayers.length - 1] += ',' + bgLayer;
 
-        if (bgLayer.indexOf('(') > -1) {
-          inParenthese = true;
-        }
-      }
-    });
+				// FIX for image-set function
+				if (unifiedLayers[unifiedLayers.length - 1].includes('image-set')) {
+					if (bgLayer.indexOf(')') > -1 && bgLayer[bgLayer.lenght] === ')') { 
+						inParenthese = false;
+					}
+				} else {
+					if (bgLayer.indexOf(')') > -1) {
+						inParenthese = false;
+					}
+				}
+			}
+			else {
+				unifiedLayers.push(bgLayer);
 
-    bgProps[property] = unifiedLayers;
-  });
+				if (bgLayer.indexOf('(') > -1) {
+					inParenthese = true;
+				}
+			}
 
-  var nbLayers = bgProps['background-image'].length;
-  var bgLayerProperties = ['background-image', 'background-repeat', 'background-position', 'background-attachment', 'background-origin', 'background-clip', 'background-size'];
+		});
+		bgProps[property] = unifiedLayers;
 
-  // Define default bg position if it's undefined and we have defined a bg size
-  if (!bgProps['background-position'][0] && bgProps['background-size'][0]) {
-    bgProps['background-position'][0] = '0 0';
-  }
+	});
 
-  // Replicate properties that are just defined once accross all layers
-  bgLayerProperties.forEach(function(layerProperty) {
-    if (bgProps[layerProperty].length < nbLayers) {
-      for (var i = bgProps[layerProperty].length ; i < nbLayers ; i++) {
-        bgProps[layerProperty].push(bgProps[layerProperty][0]);
-      }
-    }
-  });
+	var nbLayers = bgProps['background-image'].length;
+	var bgLayerProperties = ['background-image', 'background-repeat', 'background-position', 'background-attachment', 'background-origin', 'background-clip', 'background-size'];
 
-  // Stringify the properties
-  var shorthandedProperty = "";
+	// Define default bg position if it's undefined and we have defined a bg size
+	if (!bgProps['background-position'][0] && bgProps['background-size'][0]) {
+		bgProps['background-position'][0] = '0 0';
+	}
 
-  for (var i = 0 ; i < nbLayers ; i++) {
-    var layerShorthand = shorthand.shorthandSyntax;
-    if (i > 0) layerShorthand = ', ' + layerShorthand;
+	// Replicate properties that are just defined once accross all layers
+	bgLayerProperties.forEach(function (layerProperty) {
+		if (bgProps[layerProperty].length < nbLayers) {
+			for (var i = bgProps[layerProperty].length; i < nbLayers; i++) {
+				bgProps[layerProperty].push(bgProps[layerProperty][0]);
+			}
+		}
+	});
 
-    bgLayerProperties.forEach(function(bgLayerProperty) {
-      if (bgProps[bgLayerProperty][i]) {
-        layerShorthand = layerShorthand.replace(bgLayerProperty, bgProps[bgLayerProperty][i]);
-      }
-      else {
-        layerShorthand = layerShorthand.replace(bgLayerProperty, '');
-      }
+	// Stringify the properties
+	var shorthandedProperty = "";
 
-      layerShorthand = layerShorthand.replace('background-color', '');
-    });
+	for (var i = 0; i < nbLayers; i++) {
+		var layerShorthand = shorthand.shorthandSyntax;
+		if (i > 0) layerShorthand = ', ' + layerShorthand;
 
-    // Separate background-size from background-position with a slash only if background-size is specified
-    if (bgProps['background-size'][i]) {
-      layerShorthand = layerShorthand.replace('{{bg-position-size-slash}}', '/');
-    }
-    else {
-      layerShorthand = layerShorthand.replace('{{bg-position-size-slash}}', '');
-    }
+		bgLayerProperties.forEach(function (bgLayerProperty) {
+			if (bgProps[bgLayerProperty][i]) {
+				layerShorthand = layerShorthand.replace(bgLayerProperty, bgProps[bgLayerProperty][i]);
+			}
+			else {
+				layerShorthand = layerShorthand.replace(bgLayerProperty, '');
+			}
 
-    shorthandedProperty += layerShorthand.trim();
-  }
+			layerShorthand = layerShorthand.replace('background-color', '');
+		});
 
-  shorthandedProperty += ' ' + (bgProps['background-color'][0] || "");
+		// Separate background-size from background-position with a slash only if background-size is specified
+		if (bgProps['background-size'][i]) {
+			layerShorthand = layerShorthand.replace('{{bg-position-size-slash}}', '/');
+		}
+		else {
+			layerShorthand = layerShorthand.replace('{{bg-position-size-slash}}', '');
+		}
 
-  return shorthandedProperty.replace(/\s+/g, ' ').trim();
+		shorthandedProperty += layerShorthand.trim();
+	}
+
+	shorthandedProperty += ' ' + (bgProps['background-color'][0] || "");
+
+	return shorthandedProperty.replace(/\s+/g, ' ').trim();
 };

--- a/lib/shorthanders/background.js
+++ b/lib/shorthanders/background.js
@@ -12,8 +12,8 @@ module.exports = function (shorthand, declarations) {
 			if (inParenthese) {
 				unifiedLayers[unifiedLayers.length - 1] = unifiedLayers[unifiedLayers.length - 1] += ',' + bgLayer;
 
-				// FIX for image-set function
-				if (unifiedLayers[unifiedLayers.length - 1].includes('image-set')) {
+				//! FIX for image-set function and gradient
+				if (unifiedLayers[unifiedLayers.length - 1].includes('image-set') || unifiedLayers[unifiedLayers.length - 1].includes('gradient')) {
 					if (bgLayer.indexOf(')') > -1 && bgLayer[bgLayer.lenght] === ')') { 
 						inParenthese = false;
 					}


### PR DESCRIPTION
Hi! When I used your plugin with gulp, I found some issue width image-set function with background property. 

My bug was about additional adding of background-repeat, background-position and background-size and poproperties for additional url.

Input:
```css
.test {
	background-color: var(--color-dark);
	background-image: image-set(
		url("../images/cover.png") type("image/png") 1x,
		url("../images/cover@2x.png") type("image/png") 2x,
		url("../images/cover@3x.png") type("image/png") 3x
		);
	background-position: center;
	background-size: cover;
	background-repeat: no-repeat;
}
```

Output:
```css
.test {
	background: image-set( url("../images/cover.png") type("image/png") 1x, url("../images/cover@2x.png") type("image/png") 2x no-repeat center/cover, url("../images/cover@3x.png") type("image/png") 3x ) no-repeat center/cover var(--color-dark);
}
```

So, I actually found out how to fix it, and with that fix the final output looks like this:
```css
.test {
	background: image-set( url("../images/cover.png") type("image/png") 1x, url("../images/cover@2x.png") type("image/png") 2x, url("../images/cover@3x.png") type("image/png") 3x ) no-repeat center/cover var(--color-dark);
}
```
